### PR TITLE
Add warning for "Graph (old)" panels

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,7 +15,11 @@ import (
 	"github.com/grafana/detect-angular-dashboards/output"
 )
 
-const envGrafanaToken = "GRAFANA_TOKEN"
+const (
+	envGrafanaToken = "GRAFANA_TOKEN"
+
+	pluginIDGraphOld = "graph"
+)
 
 func _main() error {
 	versionFlag := flag.Bool("version", false, "print version number")
@@ -163,7 +167,15 @@ func _main() error {
 		}
 		for _, p := range dashboard.Panels {
 			// Check panel
-			if angularDetected[p.Type] {
+			if p.Type == pluginIDGraphOld {
+				// Different warning on Graph (old)
+				dashboardOutput.Detections = append(dashboardOutput.Detections, output.Detection{
+					DetectionType: output.DetectionTypeLegacyPanel,
+					PluginID:      pluginIDGraphOld,
+					Title:         p.Title,
+				})
+			} else if angularDetected[p.Type] {
+				// Angular plugin
 				dashboardOutput.Detections = append(dashboardOutput.Detections, output.Detection{
 					DetectionType: output.DetectionTypePanel,
 					PluginID:      p.Type,

--- a/output/output.go
+++ b/output/output.go
@@ -36,7 +36,7 @@ func (d Detection) String() string {
 		return fmt.Sprintf("Found panel with angular data source %q (%q)", d.Title, d.PluginID)
 	case DetectionTypeLegacyPanel:
 		return fmt.Sprintf(`Found "Graph (old)" panel %q. `+
-			`It will be migrated to a "Timeseries" panel by Grafana when opening the dashboard.`,
+			`It can be migrated to a "Timeseries" panel by Grafana when opening the dashboard.`,
 			d.Title,
 		)
 	}

--- a/output/output.go
+++ b/output/output.go
@@ -11,21 +11,36 @@ import (
 type DetectionType string
 
 const (
-	DetectionTypePanel      DetectionType = "panel"
-	DetectionTypeDatasource DetectionType = "datasource"
+	DetectionTypePanel       DetectionType = "panel"
+	DetectionTypeDatasource  DetectionType = "datasource"
+	DetectionTypeLegacyPanel DetectionType = "legacyPanel"
 )
 
 type Detection struct {
-	PluginID      string
+	// PluginID is the plugin ID that triggered the detection.
+	PluginID string
+
+	// DetectionType identifies the type of the detection.
 	DetectionType DetectionType
-	Title         string
+
+	// Title is the title of the panel that triggered the detection.
+	// It is used so the user can identify the panel on the dashboard.
+	Title string
 }
 
 func (d Detection) String() string {
-	if d.DetectionType == DetectionTypePanel {
+	switch d.DetectionType {
+	case DetectionTypePanel:
+		return fmt.Sprintf("Found angular panel %q (%q)", d.Title, d.PluginID)
+	case DetectionTypeDatasource:
 		return fmt.Sprintf("Found panel with angular data source %q (%q)", d.Title, d.PluginID)
+	case DetectionTypeLegacyPanel:
+		return fmt.Sprintf(`Found panel with "Graph (old)" panel %q. `+
+			`It will be migrated to a "Timeseries" panel by Grafana when opening the dashboard.`,
+			d.Title,
+		)
 	}
-	return fmt.Sprintf("Found angular panel %q (%q)", d.Title, d.PluginID)
+	return ""
 }
 
 type Dashboard struct {

--- a/output/output.go
+++ b/output/output.go
@@ -35,7 +35,7 @@ func (d Detection) String() string {
 	case DetectionTypeDatasource:
 		return fmt.Sprintf("Found panel with angular data source %q (%q)", d.Title, d.PluginID)
 	case DetectionTypeLegacyPanel:
-		return fmt.Sprintf(`Found panel with "Graph (old)" panel %q. `+
+		return fmt.Sprintf(`Found "Graph (old)" panel %q. `+
 			`It will be migrated to a "Timeseries" panel by Grafana when opening the dashboard.`,
 			d.Title,
 		)


### PR DESCRIPTION
Adds a warning for all "Graph (old)" panels (pluginID: `graph`).

It will be migrated to the `timeseries` panel (its replacement), but it can cause some weird behaviour while migrating.

Example output:

```
2023/09/28 13:49:49 Detecting Angular dashboards for "http://127.0.0.1:3000/api"
2023/09/28 13:49:49 (WARNING, dependencies on private plugins won't be flagged)
2023/09/28 13:49:50 Found dashboard with Angular plugins "New dashboard Copy" "http://127.0.0.1:3000/d/GQQRb0ZIz/new-dashboard-copy":
2023/09/28 13:49:50 Found "Graph (old)" panel "example". It can be migrated to a "Timeseries" panel by Grafana when opening the dashboard.
```