### PR TITLE
Add support for Grafana 10.3.x

### DIFF
--- a/api/grafana/grafana.go
+++ b/api/grafana/grafana.go
@@ -9,7 +9,7 @@ import (
 	"github.com/grafana/detect-angular-dashboards/api"
 )
 
-var errUnknownAngularStatus = errors.New("could not determine if plugin is angular or not")
+var errUnknownAngularStatus = errors.New("could not determine if plugin is angular or not, use GCOM instead")
 
 const DefaultBaseURL = "http://127.0.0.1:3000/api"
 

--- a/api/grafana/models.go
+++ b/api/grafana/models.go
@@ -24,13 +24,13 @@ type PanelDatasource struct {
 	Type string
 }
 
-type Panel struct {
+type DashboardPanel struct {
 	Type       string
 	Title      string
 	Datasource interface{}
 }
 
 type Dashboard struct {
-	Panels        []*Panel `json:"panels"`
-	SchemaVersion int      `json:"schemaVersion"`
+	Panels        []*DashboardPanel `json:"panels"`
+	SchemaVersion int               `json:"schemaVersion"`
 }


### PR DESCRIPTION
This recent [PR](https://github.com/grafana/grafana/pull/77026) in Grafana changed the way angular plugins are exposed, so detect-angular-dashboards is not able to detect angular plugins correctly.

- Panels: changed to `x.angular.detected` (before it was `x.angularDetected`)
- Datasources: changed to `x.meta.angular.detected` (before it was (`x.angularDetected`)

This PR changes the json model used to unmarshal the frontendsettings, keeping backwards compatibility with the older schema as well.