### PR TITLE
Include part of the dashboard meta in the detection result

### DIFF
--- a/api/grafana/grafana.go
+++ b/api/grafana/grafana.go
@@ -45,10 +45,8 @@ func (cl APIClient) GetDashboards(ctx context.Context, page int) ([]ListedDashbo
 	return out, err
 }
 
-func (cl APIClient) GetDashboard(ctx context.Context, uid string) (*Dashboard, error) {
-	var out struct {
-		Dashboard *Dashboard
-	}
+func (cl APIClient) GetDashboard(ctx context.Context, uid string) (*DashboardDefinition, error) {
+	var out *DashboardDefinition
 	if err := cl.Request(ctx, http.MethodGet, "dashboards/uid/"+uid, &out); err != nil {
 		return nil, err
 	}
@@ -70,7 +68,7 @@ func (cl APIClient) GetDashboard(ctx context.Context, uid string) (*Dashboard, e
 		panel.Datasource = PanelDatasource{Type: m["type"].(string)}
 	}
 
-	return out.Dashboard, nil
+	return out, nil
 }
 
 func (cl APIClient) GetOrgs(ctx context.Context) ([]Org, error) {

--- a/api/grafana/models.go
+++ b/api/grafana/models.go
@@ -30,9 +30,24 @@ type DashboardPanel struct {
 	Datasource interface{}
 }
 
+type DashboardDefinition struct {
+	Dashboard Dashboard `json:"dashboard"`
+	Meta      Meta      `json:"meta"`
+}
+
 type Dashboard struct {
 	Panels        []*DashboardPanel `json:"panels"`
 	SchemaVersion int               `json:"schemaVersion"`
+}
+type Meta struct {
+	Slug        string `json:"slug"`
+	UpdatedBy   string `json:"updatedBy"`
+	CreatedBy   string `json:"createdBy"`
+	Created     string `json:"created"`
+	Updated     string `json:"updated"`
+	FolderUID   string `json:"folderUid"`
+	FolderTitle string `json:"folderTitle"`
+	FolderURL   string `json:"folderUrl"`
 }
 
 type Org struct {

--- a/output/output.go
+++ b/output/output.go
@@ -48,6 +48,11 @@ type Dashboard struct {
 	Detections []Detection
 	URL        string
 	Title      string
+	Folder     string
+	UpdatedBy  string
+	CreatedBy  string
+	Created    string
+	Updated    string
 }
 
 type Outputter interface {


### PR DESCRIPTION
The purpose of this PR is  to expose the folder title as well. Depending on how grafana is used, the dashboard's folder could be useful.  For example, I'm Admin of a grafana where the default org is used for public information sharing. Each team is assigned a dedicated folder. Having this meta information in the summary is useful as we know which team to contact.

The output looks like this
```
  {
    "Detections": [
      {
        "PluginID": "graph",
        "DetectionType": "legacyPanel",
        "Title": "Ups dewpoint difference"
      },
      {
        "PluginID": "graph",
        "DetectionType": "legacyPanel",
        "Title": "Dewpoint"
      },
      {
        "PluginID": "graph",
        "DetectionType": "legacyPanel",
        "Title": "Ups temperature sensors"
      },
      {
        "PluginID": "graph",
        "DetectionType": "legacyPanel",
        "Title": "Ups humidity sensors"
      }
    ],
    "URL": "https://[redacted]/d/o2HeWmZnk/ups-dewpoint",
    "Title": "Ups dewpoint",
    "Folder": "Datacenter monitoring",
    "UpdatedBy": "[reacted]",
    "CreatedBy": "[reacted]",
    "Created": "2021-07-19T12:26:36Z",
    "Updated": "2021-07-26T10:21:51Z"
  }
```