### PR TITLE
feat:  Adds support for -server mode and concurrently downloading dashboards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 detect-angular-dashboards
 dist
+.vscode

--- a/detector/detector_test.go
+++ b/detector/detector_test.go
@@ -19,7 +19,7 @@ import (
 func TestDetector(t *testing.T) {
 	t.Run("meta", func(t *testing.T) {
 		cl := NewTestAPIClient(filepath.Join("testdata", "dashboards", "graph-old.json"))
-		d := NewDetector(logger.NewLeveledLogger(false), cl, gcom.NewAPIClient())
+		d := NewDetector(logger.NewLeveledLogger(false), cl, gcom.NewAPIClient(), 5)
 		out, err := d.Run(context.Background())
 		require.NoError(t, err)
 		require.Len(t, out, 1)
@@ -31,7 +31,7 @@ func TestDetector(t *testing.T) {
 		require.Equal(t, "2023-11-07T11:13:24+01:00", out[0].Created)
 		require.Equal(t, "2024-02-21T13:09:27+01:00", out[0].Updated)
 	})
-	
+
 	type expDetection struct {
 		pluginID      string
 		detectionType output.DetectionType
@@ -112,7 +112,7 @@ func TestDetector(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			cl := NewTestAPIClient(filepath.Join("testdata", "dashboards", tc.file))
-			d := NewDetector(logger.NewLeveledLogger(false), cl, gcom.NewAPIClient())
+			d := NewDetector(logger.NewLeveledLogger(false), cl, gcom.NewAPIClient(), 5)
 			out, err := d.Run(context.Background())
 			require.NoError(t, err)
 			require.Len(t, out, 1, "should have result for one dashboard")

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -1,0 +1,30 @@
+package flags
+
+import (
+	"flag"
+	"time"
+)
+
+// Flags holds the command-line flags.
+type Flags struct {
+	Version    bool
+	Verbose    bool
+	JSONOutput bool
+	SkipTLS    bool
+	ServerMode bool
+	Interval   time.Duration
+}
+
+// parseFlags parses the command-line flags.
+func ParseFlags() Flags {
+	var flags Flags
+	flag.BoolVar(&flags.Version, "version", false, "print version number")
+	flag.BoolVar(&flags.Verbose, "v", false, "verbose output")
+	flag.BoolVar(&flags.JSONOutput, "j", false, "json output")
+	flag.BoolVar(&flags.SkipTLS, "insecure", false, "skip TLS verification")
+	flag.DurationVar(&flags.Interval, "interval", 10*time.Minute, "detection refresh interval")
+	flag.BoolVar(&flags.ServerMode, "server", false, "Run as http server instead of CLI. Output is exposed as JSON at /output. Default port is 8080. Default refersh interval is 10 minutes.")
+	flag.Parse()
+
+	return flags
+}

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -23,7 +23,7 @@ func Parse() Flags {
 	flag.BoolVar(&flags.Verbose, "v", false, "verbose output")
 	flag.BoolVar(&flags.JSONOutput, "j", false, "json output")
 	flag.BoolVar(&flags.SkipTLS, "insecure", false, "skip TLS verification")
-	flag.DurationVar(&flags.Interval, "interval", 5*time.Minute, "detection refresh interval")
+	flag.DurationVar(&flags.Interval, "interval", 5*time.Minute, "detection refresh interval when running in HTTP server mode")
 	flag.StringVar(&flags.Server, "server", "", "Run as HTTP server instead of CLI. Value must be a listen address (e.g.: 0.0.0.0:5000. Output is exposed as JSON at /output.")
 	flag.IntVar(&flags.MaxConcurrency, "max-concurrency", 10, "maximum number of concurrent dashboard downloads")
 	flag.Parse()

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -24,7 +24,7 @@ func Parse() Flags {
 	flag.BoolVar(&flags.JSONOutput, "j", false, "json output")
 	flag.BoolVar(&flags.SkipTLS, "insecure", false, "skip TLS verification")
 	flag.DurationVar(&flags.Interval, "interval", 5*time.Minute, "detection refresh interval")
-	flag.StringVar(&flags.Server, "server", "0.0.0.0:8080", "Run as http server instead of CLI. Output is exposed as JSON at /output. Default listen address is 0.0.0.0:8080. Default refersh interval is 5 minutes.")
+	flag.StringVar(&flags.Server, "server", "", "Run as http server instead of CLI. Output is exposed as JSON at /output. Default refersh interval is 5 minutes.")
 	flag.IntVar(&flags.MaxConcurrency, "max-concurrency", 10, "maximum number of concurrent dashboard downloads")
 	flag.Parse()
 

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -12,6 +12,7 @@ type Flags struct {
 	JSONOutput bool
 	SkipTLS    bool
 	ServerMode bool
+	ServerPort int
 	Interval   time.Duration
 }
 
@@ -24,6 +25,7 @@ func ParseFlags() Flags {
 	flag.BoolVar(&flags.SkipTLS, "insecure", false, "skip TLS verification")
 	flag.DurationVar(&flags.Interval, "interval", 10*time.Minute, "detection refresh interval")
 	flag.BoolVar(&flags.ServerMode, "server", false, "Run as http server instead of CLI. Output is exposed as JSON at /output. Default port is 8080. Default refersh interval is 10 minutes.")
+	flag.IntVar(&flags.ServerPort, "port", 8080, "Port to run the server on")
 	flag.Parse()
 
 	return flags

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -11,23 +11,21 @@ type Flags struct {
 	Verbose        bool
 	JSONOutput     bool
 	SkipTLS        bool
-	ServerMode     bool
-	ServerPort     int
+	Server         string
 	Interval       time.Duration
 	MaxConcurrency int
 }
 
-// parseFlags parses the command-line flags.
-func ParseFlags() Flags {
+// Parse parses the command-line flags.
+func Parse() Flags {
 	var flags Flags
 	flag.BoolVar(&flags.Version, "version", false, "print version number")
 	flag.BoolVar(&flags.Verbose, "v", false, "verbose output")
 	flag.BoolVar(&flags.JSONOutput, "j", false, "json output")
 	flag.BoolVar(&flags.SkipTLS, "insecure", false, "skip TLS verification")
-	flag.DurationVar(&flags.Interval, "interval", 10*time.Minute, "detection refresh interval")
-	flag.BoolVar(&flags.ServerMode, "server", false, "Run as http server instead of CLI. Output is exposed as JSON at /output. Default port is 8080. Default refersh interval is 10 minutes.")
-	flag.IntVar(&flags.ServerPort, "port", 8080, "Port to run the server on")
-	flag.IntVar(&flags.MaxConcurrency, "max-concurrency", 5, "maximum number of concurrent dashboard downloads")
+	flag.DurationVar(&flags.Interval, "interval", 5*time.Minute, "detection refresh interval")
+	flag.StringVar(&flags.Server, "server", "0.0.0.0:8080", "Run as http server instead of CLI. Output is exposed as JSON at /output. Default listen address is 0.0.0.0:8080. Default refersh interval is 5 minutes.")
+	flag.IntVar(&flags.MaxConcurrency, "max-concurrency", 10, "maximum number of concurrent dashboard downloads")
 	flag.Parse()
 
 	return flags

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -24,7 +24,7 @@ func Parse() Flags {
 	flag.BoolVar(&flags.JSONOutput, "j", false, "json output")
 	flag.BoolVar(&flags.SkipTLS, "insecure", false, "skip TLS verification")
 	flag.DurationVar(&flags.Interval, "interval", 5*time.Minute, "detection refresh interval")
-	flag.StringVar(&flags.Server, "server", "", "Run as http server instead of CLI. Output is exposed as JSON at /output. Default refersh interval is 5 minutes.")
+	flag.StringVar(&flags.Server, "server", "", "Run as HTTP server instead of CLI. Value must be a listen address (e.g.: 0.0.0.0:5000. Output is exposed as JSON at /output.")
 	flag.IntVar(&flags.MaxConcurrency, "max-concurrency", 10, "maximum number of concurrent dashboard downloads")
 	flag.Parse()
 

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -7,13 +7,14 @@ import (
 
 // Flags holds the command-line flags.
 type Flags struct {
-	Version    bool
-	Verbose    bool
-	JSONOutput bool
-	SkipTLS    bool
-	ServerMode bool
-	ServerPort int
-	Interval   time.Duration
+	Version        bool
+	Verbose        bool
+	JSONOutput     bool
+	SkipTLS        bool
+	ServerMode     bool
+	ServerPort     int
+	Interval       time.Duration
+	MaxConcurrency int
 }
 
 // parseFlags parses the command-line flags.
@@ -26,6 +27,7 @@ func ParseFlags() Flags {
 	flag.DurationVar(&flags.Interval, "interval", 10*time.Minute, "detection refresh interval")
 	flag.BoolVar(&flags.ServerMode, "server", false, "Run as http server instead of CLI. Output is exposed as JSON at /output. Default port is 8080. Default refersh interval is 10 minutes.")
 	flag.IntVar(&flags.ServerPort, "port", 8080, "Port to run the server on")
+	flag.IntVar(&flags.MaxConcurrency, "max-concurrency", 5, "maximum number of concurrent dashboard downloads")
 	flag.Parse()
 
 	return flags

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -24,7 +24,7 @@ func Parse() Flags {
 	flag.BoolVar(&flags.JSONOutput, "j", false, "json output")
 	flag.BoolVar(&flags.SkipTLS, "insecure", false, "skip TLS verification")
 	flag.DurationVar(&flags.Interval, "interval", 5*time.Minute, "detection refresh interval when running in HTTP server mode")
-	flag.StringVar(&flags.Server, "server", "", "Run as HTTP server instead of CLI. Value must be a listen address (e.g.: 0.0.0.0:5000. Output is exposed as JSON at /output.")
+	flag.StringVar(&flags.Server, "server", "", "Run as HTTP server instead of CLI. Value must be a listen address (e.g.: 0.0.0.0:5000. Output is exposed as JSON at /detections.")
 	flag.IntVar(&flags.MaxConcurrency, "max-concurrency", 10, "maximum number of concurrent dashboard downloads")
 	flag.Parse()
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -8,12 +8,16 @@ import (
 type Logger interface {
 	Log(format string, v ...any)
 	Warn(format string, v ...any)
+	Error(format string, v ...any)
+	Errorf(format string, v ...any)
 }
 
 type nopLogger struct{}
 
-func (nopLogger) Log(string, ...any)  {}
-func (nopLogger) Warn(string, ...any) {}
+func (nopLogger) Log(string, ...any)    {}
+func (nopLogger) Warn(string, ...any)   {}
+func (nopLogger) Error(string, ...any)  {}
+func (nopLogger) Errorf(string, ...any) {}
 
 // NewNopLogger returns a new logger whose methods are no-ops and don't log anything.
 func NewNopLogger() Logger {
@@ -23,24 +27,34 @@ func NewNopLogger() Logger {
 type LeveledLogger struct {
 	isVerbose bool
 
-	Logger     *log.Logger
-	WarnLogger *log.Logger
+	Logger      *log.Logger
+	WarnLogger  *log.Logger
+	ErrorLogger *log.Logger
 }
 
 func NewLeveledLogger(verbose bool) *LeveledLogger {
 	return &LeveledLogger{
-		isVerbose:  verbose,
-		Logger:     log.New(os.Stdout, "", log.LstdFlags),
-		WarnLogger: log.New(os.Stderr, "", log.LstdFlags),
+		isVerbose:   verbose,
+		Logger:      log.New(os.Stdout, "INFO: ", log.LstdFlags),
+		WarnLogger:  log.New(os.Stderr, "WARN: ", log.LstdFlags),
+		ErrorLogger: log.New(os.Stderr, "ERROR: ", log.LstdFlags),
 	}
 }
 
 func (l *LeveledLogger) Log(format string, v ...any) {
-	log.Printf(format, v...)
+	l.Logger.Printf(format, v...)
 }
 
 func (l *LeveledLogger) Warn(format string, v ...any) {
 	l.WarnLogger.Printf(format, v...)
+}
+
+func (l *LeveledLogger) Error(format string, v ...any) {
+	l.ErrorLogger.Printf(format, v...)
+}
+
+func (l *LeveledLogger) Errorf(format string, v ...any) {
+	l.ErrorLogger.Printf(format, v...)
 }
 
 func (l *LeveledLogger) Verbose() Logger {

--- a/main.go
+++ b/main.go
@@ -97,9 +97,11 @@ func main() {
 			http.HandleFunc("/output", func(w http.ResponseWriter, r *http.Request) {
 				handleOutputRequest(w, r, &mu, outputData, log)
 			})
-			log.Log("Listening on :8080")
-			if err := http.ListenAndServe(":8080", nil); err != nil {
-				log.Errorf("http server: %s\n", err)
+			serverAddress := fmt.Sprintf(":%d", flags.ServerPort)
+			log.Log("Listening on %s", serverAddress)
+			if err := http.ListenAndServe(serverAddress, nil); err != nil {
+				log.Errorf("Failed to setup http server: %s\n", err)
+				os.Exit(1)
 			}
 		}()
 

--- a/main.go
+++ b/main.go
@@ -107,8 +107,8 @@ func runServerMode(flags *flags.Flags, log *logger.LeveledLogger, d *detector.De
 		}
 	}()
 
-	http.HandleFunc("/output", func(w http.ResponseWriter, r *http.Request) {
-		handleOutputRequest(w, r, &out, log)
+	http.HandleFunc("/detections", func(w http.ResponseWriter, r *http.Request) {
+		handleDetectionsRequest(w, r, &out, log)
 	})
 	http.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
 		handleReadyRequest(w, r, &ready)

--- a/main.go
+++ b/main.go
@@ -69,6 +69,7 @@ func runServerMode(flags *flags.Flags, log *logger.LeveledLogger, d *detector.De
 
 	ticker := time.NewTicker(flags.Interval)
 	defer ticker.Stop()
+	log.Log("Running detection every %s", flags.Interval)
 
 	var out Output
 	go func() {

--- a/main.go
+++ b/main.go
@@ -128,7 +128,9 @@ func handleOutputRequest(w http.ResponseWriter, r *http.Request, mu *sync.Mutex,
 	defer mu.Unlock()
 	w.Header().Set("Content-Type", "application/json")
 
-	// Filter Angular dashboards to avoid modifying the original slice
+	// Have to do this because the JSONOutputter.Output method modifies the slice in place
+	// which results in werid bug where the slice gets duplicate entries. The number of duplicate entries
+	// continues to grow with each request to /output. Something is leaky
 	angularDashboards := filterAngularDashboards(outputData)
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")

--- a/main.go
+++ b/main.go
@@ -80,6 +80,7 @@ func main() {
 	go func() {
 		for data := range outputChan {
 			log.Log("Updating outputData with results from most recent detection")
+			// Need to lock to avoid concurrent read/write access to outputData
 			mu.Lock()
 			outputData = data
 			mu.Unlock()

--- a/main.go
+++ b/main.go
@@ -7,6 +7,9 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/grafana/detect-angular-dashboards/api"
 	"github.com/grafana/detect-angular-dashboards/api/gcom"
@@ -17,12 +20,11 @@ import (
 	"github.com/grafana/detect-angular-dashboards/output"
 )
 
-const (
-	envGrafanaToken = "GRAFANA_TOKEN"
-)
+const envGrafanaToken = "GRAFANA_TOKEN"
 
-func newLogger(verboseFlag, jsonOutputFlag bool) *logger.LeveledLogger {
-	log := logger.NewLeveledLogger(verboseFlag)
+// newLogger initializes a new leveled logger.
+func newLogger(verbose, jsonOutputFlag bool) *logger.LeveledLogger {
+	log := logger.NewLeveledLogger(verbose)
 	if jsonOutputFlag {
 		// Redirect everything to stderr to avoid mixing with json output
 		log.Logger.SetOutput(os.Stderr)
@@ -31,6 +33,7 @@ func newLogger(verboseFlag, jsonOutputFlag bool) *logger.LeveledLogger {
 	return log
 }
 
+// getToken retrieves the Grafana token from the environment variable.
 func getToken() (string, error) {
 	token := os.Getenv(envGrafanaToken)
 	if token == "" {
@@ -39,51 +42,19 @@ func getToken() (string, error) {
 	return token, nil
 }
 
-func main() {
-	versionFlag := flag.Bool("version", false, "print version number")
-	verboseFlag := flag.Bool("v", false, "verbose output")
-	jsonOutputFlag := flag.Bool("j", false, "json output")
-	skipTLSFlag := flag.Bool("insecure", false, "skip TLS verification")
-	flag.Parse()
+// runDetection performs the detection of Angular dashboards.
+func runDetection(ctx context.Context, log *logger.LeveledLogger, client grafana.APIClient, jsonOutputFlag bool) {
+	log.Log("Detecting Angular dashboards")
 
-	if *versionFlag {
-		fmt.Printf("%s %s (%s)\n", os.Args[0], build.LinkerVersion, build.LinkerCommitSHA)
-		os.Exit(0)
-	}
-	log := newLogger(*verboseFlag, *jsonOutputFlag)
-
-	token, err := getToken()
-	if err != nil {
-		_, _ = fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
-	}
-
-	ctx := context.Background()
-	grafanaURL := grafana.DefaultBaseURL
-	if flag.NArg() >= 1 {
-		grafanaURL = flag.Arg(0)
-	}
-
-	log.Log("Detecting Angular dashboards for %q", grafanaURL)
-
-	opts := []api.ClientOption{api.WithAuthentication(token)}
-	if *skipTLSFlag {
-		opts = append(opts, api.WithHTTPClient(&http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			},
-		}))
-	}
-	client := grafana.NewAPIClient(api.NewClient(grafanaURL, opts...))
 	d := detector.NewDetector(log, client, gcom.NewAPIClient())
 	finalOutput, err := d.Run(ctx)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "%s\n", err)
-		os.Exit(0)
+		log.Errorf("%s\n", err)
+		return
 	}
 
 	var out output.Outputter
-	if *jsonOutputFlag {
+	if jsonOutputFlag {
 		out = output.NewJSONOutputter(os.Stdout)
 	} else {
 		out = output.NewLoggerReadableOutput(log)
@@ -91,6 +62,81 @@ func main() {
 
 	// Print output
 	if err := out.Output(finalOutput); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "output: %s\n", err)
+		log.Errorf("output: %s\n", err)
+	}
+}
+
+// parseFlags parses the command-line flags.
+func parseFlags() (bool, bool, bool, bool, time.Duration) {
+	versionFlag := flag.Bool("version", false, "print version number")
+	verboseFlag := flag.Bool("v", false, "verbose output")
+	jsonOutputFlag := flag.Bool("j", false, "json output")
+	skipTLSFlag := flag.Bool("insecure", false, "skip TLS verification")
+	intervalFlag := flag.Duration("interval", 10*time.Minute, "detection interval")
+	flag.Parse()
+
+	return *versionFlag, *verboseFlag, *jsonOutputFlag, *skipTLSFlag, *intervalFlag
+}
+
+func main() {
+	versionFlag, verboseFlag, jsonOutputFlag, skipTLSFlag, interval := parseFlags()
+
+	if versionFlag {
+		fmt.Printf("%s %s (%s)\n", os.Args[0], build.LinkerVersion, build.LinkerCommitSHA)
+		os.Exit(0)
+	}
+	log := newLogger(verboseFlag, jsonOutputFlag)
+
+	token, err := getToken()
+	if err != nil {
+		log.Error(err.Error())
+		os.Exit(1)
+	}
+
+	grafanaURL := grafana.DefaultBaseURL
+	if flag.NArg() >= 1 {
+		grafanaURL = flag.Arg(0)
+	}
+
+	opts := []api.ClientOption{api.WithAuthentication(token)}
+	if skipTLSFlag {
+		opts = append(opts, api.WithHTTPClient(&http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+		}))
+	}
+	client := grafana.NewAPIClient(api.NewClient(grafanaURL, opts...))
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Handle graceful shutdown
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		<-sigs
+		log.Log("Received shutdown signal")
+		cancel()
+		ticker.Stop()
+	}()
+
+	// Run detection on startup
+	runDetection(ctx, log, client, jsonOutputFlag)
+
+	// Run detection periodically
+	log.Log("Starting periodic detection loop with interval %s", interval)
+	for {
+		select {
+		case <-ctx.Done():
+			log.Log("Shutting down")
+			return
+		case <-ticker.C:
+			runDetection(ctx, log, client, jsonOutputFlag)
+		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -125,7 +125,7 @@ func main() {
 	}
 
 	// Run detection on startup
-	runDetection(ctx, log, client, outputChan)
+	runDetection(ctx, log, client, flags.MaxConcurrency, outputChan)
 
 	for {
 		select {
@@ -133,7 +133,7 @@ func main() {
 			log.Log("Shutting down")
 			return
 		case <-ticker.C:
-			runDetection(ctx, log, client, outputChan)
+			runDetection(ctx, log, client, flags.MaxConcurrency, outputChan)
 		}
 	}
 }
@@ -210,10 +210,10 @@ func getToken() (string, error) {
 }
 
 // runDetection performs the detection of Angular dashboards and sends the output to a channel.
-func runDetection(ctx context.Context, log *logger.LeveledLogger, client grafana.APIClient, outputChan chan<- []output.Dashboard) {
+func runDetection(ctx context.Context, log *logger.LeveledLogger, client grafana.APIClient, maxConcurrency int, outputChan chan<- []output.Dashboard) {
 	log.Log("Detecting Angular dashboards")
 
-	d := detector.NewDetector(log, client, gcom.NewAPIClient())
+	d := detector.NewDetector(log, client, gcom.NewAPIClient(), maxConcurrency)
 	finalOutput, err := d.Run(ctx)
 	if err != nil {
 		log.Errorf("%s\n", err)

--- a/main.go
+++ b/main.go
@@ -190,8 +190,8 @@ func initializeClient(token string, flags *flags.Flags) grafana.APIClient {
 	return grafana.NewAPIClient(api.NewClient(grafanaURL, opts...))
 }
 
-// handleOutputRequest handles the /output HTTP endpoint.
-func handleOutputRequest(w http.ResponseWriter, r *http.Request, output *Output, log *logger.LeveledLogger) {
+// handleDetectionsRequest handles the /output HTTP endpoint.
+func handleDetectionsRequest(w http.ResponseWriter, r *http.Request, output *Output, log *logger.LeveledLogger) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return


### PR DESCRIPTION
This is a useful script. However it is a pain to manually re-run the script to keep track of a migration. This PR: 

- Adds an HTTP Server which returns the list of angular dashboard as a JSON response on the `/output` route.  
- Adds a flag to configure the server port (default 8080). 
- Setups up a background go routine to update on a specified interval (default 10m). 
- Adds a flag to specify custom refresh interval. 
- Moves flag parsing into a new package. 
- Extends LeveledLogger with an ErrorLogger. 
- Adds readiness probe since detections can take 5+ minutes to run. 
- Adds signal handling. 
- Adds support for concurrently download dashboards to speed up detection runs (default 5) 
- General tidying.

**This can now be hooked up directly to Grafana via the infinity data source plugin for live migration tracking.**

Usage: 
```
detect-angular-dashboards -server -interval 5m -max-concurrency 10 https://<grafana_instance>/api
```

Note: There was a strange bug with using  JSONOutputter.Output to filter the angular dashboards which resulted in a increasing number of duplicates with each request to the /output endpoint. My suspicion is its something to do with in place filtering of the Dashboards slice. I eventually decided to write my own version which seems to be working as expected `filterAngularDashboards`. 