### PR TITLE
Use new isLegacyPanel function, fix tests

### DIFF
--- a/detector/detector.go
+++ b/detector/detector.go
@@ -275,7 +275,7 @@ func (d *Detector) checkPanel(dashboardDefinition *grafana.DashboardDefinition, 
 	var out []output.Detection
 
 	// Check panel
-	if p.Type == pluginIDGraphOld || p.Type == pluginIDTableOld || (p.Type == pluginIDTable && dashboardDefinition.Dashboard.SchemaVersion < 24) {
+	if d.isLegacyPanel(p.Type, dashboardDefinition.Dashboard.SchemaVersion) {
 		// Different warning on legacy panel that can be migrated to React automatically
 		out = append(out, output.Detection{
 			DetectionType: output.DetectionTypeLegacyPanel,

--- a/detector/detector_test.go
+++ b/detector/detector_test.go
@@ -55,12 +55,12 @@ func TestDetector(t *testing.T) {
 		},
 		{
 			name: "angular panel",
-			file: "worldmap.json",
+			file: "datatable.json",
 			expDetections: []expDetection{{
-				pluginID:      "grafana-worldmap-panel",
+				pluginID:      "briangann-datatable-panel",
 				detectionType: output.DetectionTypePanel,
 				title:         "Panel Title",
-				message:       `Found angular panel "Panel Title" ("grafana-worldmap-panel")`,
+				message:       `Found angular panel "Panel Title" ("briangann-datatable-panel")`,
 			}},
 		},
 		{
@@ -78,8 +78,8 @@ func TestDetector(t *testing.T) {
 			file: "multiple.json",
 			expDetections: []expDetection{
 				{pluginID: "akumuli-datasource", detectionType: output.DetectionTypeDatasource, title: "akumuli"},
-				{pluginID: "grafana-worldmap-panel", detectionType: output.DetectionTypePanel, title: "worldmap + akumuli"},
-				{pluginID: "akumuli-datasource", detectionType: output.DetectionTypeDatasource, title: "worldmap + akumuli"},
+				{pluginID: "briangann-datatable-panel", detectionType: output.DetectionTypePanel, title: "datatable + akumuli"},
+				{pluginID: "akumuli-datasource", detectionType: output.DetectionTypeDatasource, title: "datatable + akumuli"},
 				{pluginID: "graph", detectionType: output.DetectionTypeLegacyPanel, title: "graph-old"},
 			},
 		},
@@ -92,21 +92,21 @@ func TestDetector(t *testing.T) {
 			name: "mix of angular and react",
 			file: "mixed.json",
 			expDetections: []expDetection{
-				{pluginID: "grafana-worldmap-panel", detectionType: output.DetectionTypePanel, title: "angular"},
+				{pluginID: "briangann-datatable-panel", detectionType: output.DetectionTypePanel, title: "angular"},
 			},
 		},
 		{
 			name: "rows expanded",
 			file: "rows-expanded.json",
 			expDetections: []expDetection{
-				{pluginID: "grafana-worldmap-panel", detectionType: output.DetectionTypePanel, title: "expanded"},
+				{pluginID: "briangann-datatable-panel", detectionType: output.DetectionTypePanel, title: "expanded"},
 			},
 		},
 		{
 			name: "rows collapsed",
 			file: "rows-collapsed.json",
 			expDetections: []expDetection{
-				{pluginID: "grafana-worldmap-panel", detectionType: output.DetectionTypePanel, title: "collapsed"},
+				{pluginID: "briangann-datatable-panel", detectionType: output.DetectionTypePanel, title: "collapsed"},
 			},
 		},
 	} {

--- a/detector/testdata/dashboards/datatable.json
+++ b/detector/testdata/dashboards/datatable.json
@@ -62,7 +62,7 @@
       },
       "thresholds": "0,10",
       "title": "Panel Title",
-      "type": "grafana-worldmap-panel",
+      "type": "briangann-datatable-panel",
       "unitPlural": "",
       "unitSingle": "",
       "valueName": "total"

--- a/detector/testdata/dashboards/mixed.json
+++ b/detector/testdata/dashboards/mixed.json
@@ -244,7 +244,7 @@
       },
       "thresholds": "0,10",
       "title": "angular",
-      "type": "grafana-worldmap-panel",
+      "type": "briangann-datatable-panel",
       "unitPlural": "",
       "unitSingle": "",
       "valueName": "total"

--- a/detector/testdata/dashboards/multiple.json
+++ b/detector/testdata/dashboards/multiple.json
@@ -153,8 +153,8 @@
         "queryType": "geohash"
       },
       "thresholds": "0,10",
-      "title": "worldmap + akumuli",
-      "type": "grafana-worldmap-panel",
+      "title": "datatable + akumuli",
+      "type": "briangann-datatable-panel",
       "unitPlural": "",
       "unitSingle": "",
       "valueName": "total"

--- a/detector/testdata/dashboards/rows-collapsed.json
+++ b/detector/testdata/dashboards/rows-collapsed.json
@@ -72,7 +72,7 @@
           },
           "thresholds": "0,10",
           "title": "collapsed",
-          "type": "grafana-worldmap-panel",
+          "type": "briangann-datatable-panel",
           "unitPlural": "",
           "unitSingle": "",
           "valueName": "total"

--- a/detector/testdata/dashboards/rows-expanded.json
+++ b/detector/testdata/dashboards/rows-expanded.json
@@ -75,7 +75,7 @@
       },
       "thresholds": "0,10",
       "title": "expanded",
-      "type": "grafana-worldmap-panel",
+      "type": "briangann-datatable-panel",
       "unitPlural": "",
       "unitSingle": "",
       "valueName": "total"

--- a/detector/testdata/frontend-settings.json
+++ b/detector/testdata/frontend-settings.json
@@ -3687,6 +3687,84 @@
         "hideDeprecation": false
       }
     },
+    "briangann-datatable-panel": {
+      "id": "briangann-datatable-panel",
+      "name": "Datatable Panel",
+      "info": {
+        "author": {
+          "name": "Brian Gann (bkgann@gmail.com)",
+          "url": "https://github.com/briangann"
+        },
+        "description": "Datatable panel for Grafana",
+        "links": [
+          {
+            "name": "Project site",
+            "url": "https://github.com/briangann/grafana-datatable-panel"
+          },
+          {
+            "name": "MIT License",
+            "url": "https://github.com/briangann/grafana-datatable-panel/blob/master/LICENSE"
+          }
+        ],
+        "logos": {
+          "small": "public/plugins/briangann-datatable-panel/img/nav-dt.png",
+          "large": "public/plugins/briangann-datatable-panel/img/nav-dt.png"
+        },
+        "build": {},
+        "screenshots": [
+          {
+            "name": "Showcase Paging",
+            "path": "public/plugins/briangann-datatable-panel/screenshots/datatable-default-paging.png"
+          },
+          {
+            "name": "Showcase Scrolling",
+            "path": "public/plugins/briangann-datatable-panel/screenshots/datatable-scroll.png"
+          },
+          {
+            "name": "Showcase Compact Numbered",
+            "path": "public/plugins/briangann-datatable-panel/screenshots/datatable-compact-numbered.png"
+          },
+          {
+            "name": "Options",
+            "path": "public/plugins/briangann-datatable-panel/screenshots/datatable-options.png"
+          },
+          {
+            "name": "Datatable Options",
+            "path": "public/plugins/briangann-datatable-panel/screenshots/datatable-dt-options.png"
+          },
+          {
+            "name": "Thresholding with Row Coloring",
+            "path": "public/plugins/briangann-datatable-panel/screenshots/datatable-threshold-row.png"
+          },
+          {
+            "name": "Thresholding with Cell Coloring",
+            "path": "public/plugins/briangann-datatable-panel/screenshots/datatable-threshold-cell.png"
+          },
+          {
+            "name": "Thresholding with Value Coloring",
+            "path": "public/plugins/briangann-datatable-panel/screenshots/datatable-threshold-value.png"
+          }
+        ],
+        "version": "1.0.4",
+        "updated": "2023-09-12",
+        "keywords": [
+          "table",
+          "panel"
+        ]
+      },
+      "hideFromList": false,
+      "sort": 100,
+      "skipDataQuery": false,
+      "state": "",
+      "baseUrl": "public/plugins/briangann-datatable-panel",
+      "signature": "valid",
+      "module": "public/plugins/briangann-datatable-panel/module.js",
+      "angular": {
+        "detected": true,
+        "hideDeprecation": false
+      },
+      "loadingStrategy": "fetch"
+    },
     "candlestick": {
       "id": "candlestick",
       "name": "Candlestick",

--- a/detector/testdata/plugins.json
+++ b/detector/testdata/plugins.json
@@ -2499,5 +2499,91 @@
     "signatureOrg": "",
     "angularDetected": false,
     "apiVersion": ""
+  },
+  {
+    "name": "Datatable Panel",
+    "type": "panel",
+    "id": "briangann-datatable-panel",
+    "enabled": true,
+    "pinned": false,
+    "info": {
+      "author": {
+        "name": "Brian Gann (bkgann@gmail.com)",
+        "url": "https://github.com/briangann"
+      },
+      "description": "Datatable panel for Grafana",
+      "links": [
+        {
+          "name": "Project site",
+          "url": "https://github.com/briangann/grafana-datatable-panel"
+        },
+        {
+          "name": "MIT License",
+          "url": "https://github.com/briangann/grafana-datatable-panel/blob/master/LICENSE"
+        }
+      ],
+      "logos": {
+        "small": "public/plugins/briangann-datatable-panel/img/nav-dt.png",
+        "large": "public/plugins/briangann-datatable-panel/img/nav-dt.png"
+      },
+      "build": {},
+      "screenshots": [
+        {
+          "name": "Showcase Paging",
+          "path": "public/plugins/briangann-datatable-panel/screenshots/datatable-default-paging.png"
+        },
+        {
+          "name": "Showcase Scrolling",
+          "path": "public/plugins/briangann-datatable-panel/screenshots/datatable-scroll.png"
+        },
+        {
+          "name": "Showcase Compact Numbered",
+          "path": "public/plugins/briangann-datatable-panel/screenshots/datatable-compact-numbered.png"
+        },
+        {
+          "name": "Options",
+          "path": "public/plugins/briangann-datatable-panel/screenshots/datatable-options.png"
+        },
+        {
+          "name": "Datatable Options",
+          "path": "public/plugins/briangann-datatable-panel/screenshots/datatable-dt-options.png"
+        },
+        {
+          "name": "Thresholding with Row Coloring",
+          "path": "public/plugins/briangann-datatable-panel/screenshots/datatable-threshold-row.png"
+        },
+        {
+          "name": "Thresholding with Cell Coloring",
+          "path": "public/plugins/briangann-datatable-panel/screenshots/datatable-threshold-cell.png"
+        },
+        {
+          "name": "Thresholding with Value Coloring",
+          "path": "public/plugins/briangann-datatable-panel/screenshots/datatable-threshold-value.png"
+        }
+      ],
+      "version": "1.0.4",
+      "updated": "2023-09-12",
+      "keywords": [
+        "table",
+        "panel"
+      ]
+    },
+    "dependencies": {
+      "grafanaDependency": "\u003e=8.0.7",
+      "grafanaVersion": "*",
+      "plugins": [],
+      "extensions": {
+        "exposedComponents": []
+      }
+    },
+    "latestVersion": "",
+    "hasUpdate": false,
+    "defaultNavUrl": "/plugins/briangann-datatable-panel/",
+    "category": "",
+    "state": "",
+    "signature": "valid",
+    "signatureType": "community",
+    "signatureOrg": "Brian Gann",
+    "angularDetected": true
   }
 ]


### PR DESCRIPTION
Follow up to #25

- Ensures the new function `isLegacyPanel` introduced in #25 is used.

- Updates the tests so `briangann-datatable-panel` is used instead of `grafana-worldmap-panel` as "external" angular plugin