### PR TITLE
chore(renovate): extend shared grafana-catalog-team preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "ignorePresets": [
+    "github>grafana/grafana-renovate-config//presets/base",
+    "github>grafana/grafana-renovate-config//presets/automerge",
+    "github>grafana/grafana-renovate-config//presets/labels",
+    "github>grafana/grafana-renovate-config//presets/npm"
+  ],
+  "extends": ["github>grafana/grafana-catalog-team//renovate/renovate"]
+}


### PR DESCRIPTION
Adds a Renovate config that extends the shared grafana-catalog-team preset (github>grafana/grafana-catalog-team//renovate/renovate), so this repo picks up the team Renovate defaults. It had no Renovate config before.

The file carries the standard ignorePresets block because ignorePresets is not inherited from extended presets (renovatebot/renovate#14818), so it has to live in the repo own config to switch off the base, automerge, labels, and npm presets the team preset deliberately turns off.

Part of grafana/grafana-catalog-team#1052.