### PR TITLE
fix(renovate-approve): use latestReviews so the guard works with the app token

### DIFF
--- a/.github/workflows/renovate-approve.yml
+++ b/.github/workflows/renovate-approve.yml
@@ -256,9 +256,15 @@ jobs:
           fi
           printf '%s\n' "$verdict"
 
-          reviews=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json reviews)
-          changes_requested=$(jq '[.reviews[] | select(.state == "CHANGES_REQUESTED")] | length' <<<"$reviews")
-          bot_approved=$(jq '[.reviews[] | select((.author.login | startswith("grafana-plugins-platform-bot")) and .state == "APPROVED")] | length' <<<"$reviews")
+          # latestReviews, not reviews: `--json reviews` also asks GraphQL for
+          # reviews.nodes[].commit, which needs `contents: read`. The app token
+          # only carries `pull_requests: write`, so that query fails outright as
+          # soon as the PR has any review, including one a rebase dismissed.
+          # latestReviews leaves the commit field out and is the better question
+          # anyway: only a reviewer's current position should count here.
+          reviews=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json latestReviews)
+          changes_requested=$(jq '[.latestReviews[] | select(.state == "CHANGES_REQUESTED")] | length' <<<"$reviews")
+          bot_approved=$(jq '[.latestReviews[] | select((.author.login | startswith("grafana-plugins-platform-bot")) and .state == "APPROVED")] | length' <<<"$reviews")
 
           case "$verdict" in
             "VERDICT: approve"*)


### PR DESCRIPTION
The `Post gate decision` step re-reads the PR's reviews before posting, so that a human requesting changes still wins. It did that with `gh pr view --json reviews`, and gh's GraphQL query for `reviews` also asks for `reviews.nodes[].commit`. That subfield needs `contents: read`, and the minted app token only carries `pull_requests: write`, so the call fails with:

```
GraphQL: Resource not accessible by integration (repository.pullRequest.reviews.nodes.0.commit)
```

It only trips once the PR already has at least one review, and a review dismissed by a rebase counts. So the sweep pays for a full Claude review, gets a verdict, then dies before posting it, and repeats on the next sweep. Across the gate repos that is 272 failed runs in the last 14 days and 17 open renovate PRs stuck this way, the oldest since 4 August.

`--json latestReviews` does not request the commit field, so the token stays as it is. It is also the better question for this guard: it returns each reviewer's current position, so a `CHANGES_REQUESTED` that the reviewer later withdrew no longer blocks the approval, and a bot approval that a rebase dismissed correctly reads as "not approved" instead of counting forever.

Same change goes to every gate repo. Refs grafana/grafana-catalog-team#1052
